### PR TITLE
chore: add prime method

### DIFF
--- a/dataloader.go
+++ b/dataloader.go
@@ -160,6 +160,13 @@ func (l *Dataloader[K, T]) Load(key K) *Result[T] {
 	return &res
 }
 
+func (l *Dataloader[K, T]) Prime(key K, data T) {
+	l.cond.L.Lock()
+	l.data[key] = Result[T]{Data: data, dirty: true}
+	l.cond.L.Unlock()
+	l.cond.Broadcast()
+}
+
 func (l *Dataloader[K, T]) isFetching(key K) bool {
 	res, ok := l.data[key]
 	return !ok || !res.IsSet()

--- a/examples/main.go
+++ b/examples/main.go
@@ -15,8 +15,7 @@ type User struct {
 }
 
 func main() {
-	fmt.Println("Hello, world!")
-	dl, close := dataloader.New[string, User](func(keys []string) (map[string]dataloader.Result[User], error) {
+	dl, flush := dataloader.New(func(keys []string) (map[string]dataloader.Result[User], error) {
 		fmt.Println("batchFn", keys)
 		if len(keys) == 1 {
 			return nil, errors.New("intended error")
@@ -27,12 +26,15 @@ func main() {
 		}
 		return m, nil
 	}, 16*time.Millisecond)
-	defer close()
+	defer flush()
 
 	n := 100
 
 	var wg sync.WaitGroup
 	wg.Add(n)
+
+	dl.Prime("test", User{Name: "test"})
+	fmt.Println(dl.Load("test"))
 
 	for i := 0; i < n; i++ {
 		go func(i int) {


### PR DESCRIPTION
Allow setting the value for a given key. Useful for fetching nested entities in graphql, where the initial root data has been fetched first:

```graphql
type User {
  Friends: [User!]!
}
```